### PR TITLE
slack : 형식에 맞지 않는 예약이 있을 경우 조회시 무시하게 변경

### DIFF
--- a/src/main/java/com/h3/reservation/common/MeetingRoom.java
+++ b/src/main/java/com/h3/reservation/common/MeetingRoom.java
@@ -16,15 +16,6 @@ public enum MeetingRoom {
         this.name = name;
     }
 
-    public static MeetingRoom of(String name) {
-        for (MeetingRoom room : values()) {
-            if (room.getName().equals(name)) {
-                return room;
-            }
-        }
-        throw new IllegalArgumentException();
-    }
-
     public static MeetingRoom findByName(String name) {
         return Arrays.stream(values())
                 .filter(room -> room.name.equals(name))

--- a/src/main/java/com/h3/reservation/slack/service/SlackService.java
+++ b/src/main/java/com/h3/reservation/slack/service/SlackService.java
@@ -90,7 +90,7 @@ public class SlackService {
     }
 
     public ModalUpdateResponse updateReservationModal(ReserveRequest request) throws IOException {
-        ReservationDetails details = ReservationDetails.of(MeetingRoom.of(request.getMeetingRoom()), request.getName(), request.getDescription());
+        ReservationDetails details = ReservationDetails.of(MeetingRoom.findByName(request.getMeetingRoom()), request.getName(), request.getDescription());
         DateTime dateTime = DateTime.of(request.getDate()
             , generateLocalTime(request.getStartHour(), request.getStartMinute())
             , generateLocalTime(request.getEndHour(), request.getEndMinute()));

--- a/src/main/java/com/h3/reservation/slackcalendar/converter/ReservationConverter.java
+++ b/src/main/java/com/h3/reservation/slackcalendar/converter/ReservationConverter.java
@@ -10,6 +10,7 @@ import com.h3.reservation.slackcalendar.domain.Reservation;
  * @date 2019-12-10
  */
 public class ReservationConverter {
+    private static final int SUMMARY_VALID_SIZE = 3;
     private static final int SUMMARY_ROOM_INDEX = 0;
     private static final int SUMMARY_BOOKER_INDEX = 1;
     private static final int SUMMARY_PURPOSE_INDEX = 2;
@@ -21,6 +22,22 @@ public class ReservationConverter {
     private static final int TIME_MINUTE_INDEX = 1;
 
     private ReservationConverter() {
+    }
+
+    public static boolean isFormatted(String summary, String summaryDelimiter) {
+        return isValidateFormat(summary.split(summaryDelimiter));
+    }
+
+    private static boolean isValidateFormat(String[] summaries) {
+        return isValidSize(summaries) && isValidMeetingRoom(summaries[SUMMARY_ROOM_INDEX]);
+    }
+
+    private static boolean isValidSize(String[] summaries) {
+        return summaries.length == SUMMARY_VALID_SIZE;
+    }
+
+    private static boolean isValidMeetingRoom(String summary) {
+        return !MeetingRoom.NONE.equals(MeetingRoom.findByName(summary));
     }
 
     public static Reservation toReservation(Event event, String summaryDelimiter) {

--- a/src/main/java/com/h3/reservation/slackcalendar/converter/ReservationConverter.java
+++ b/src/main/java/com/h3/reservation/slackcalendar/converter/ReservationConverter.java
@@ -29,7 +29,7 @@ public class ReservationConverter {
         String endDateTime = event.getEnd().getDateTime().toString();
 
         return Reservation.of(
-            MeetingRoom.of(summary[SUMMARY_ROOM_INDEX]), summary[SUMMARY_BOOKER_INDEX], summary[SUMMARY_PURPOSE_INDEX]
+            MeetingRoom.findByName(summary[SUMMARY_ROOM_INDEX]), summary[SUMMARY_BOOKER_INDEX], summary[SUMMARY_PURPOSE_INDEX]
             , parseDate(startDateTime), parseTime(startDateTime), parseTime(endDateTime)
         );
     }

--- a/src/main/java/com/h3/reservation/slackcalendar/service/SlackCalendarService.java
+++ b/src/main/java/com/h3/reservation/slackcalendar/service/SlackCalendarService.java
@@ -41,6 +41,7 @@ public class SlackCalendarService {
 
         return Reservations.of(
             reservation.getEvents().stream()
+                .filter(event -> ReservationConverter.isFormatted(event.getSummary(), summaryDelimiter))
                 .map(event -> ReservationConverter.toReservation(event, summaryDelimiter))
                 .sorted(Comparator.comparing(Reservation::getFormattedStartTime))
                 .collect(Collectors.toList())

--- a/src/test/java/com/h3/reservation/common/MeetingRoomTest.java
+++ b/src/test/java/com/h3/reservation/common/MeetingRoomTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class MeetingRoomTest {
     @Test
-    void of() {
-        MeetingRoom room = MeetingRoom.of("회의실1");
+    void findByName() {
+        MeetingRoom room = MeetingRoom.findByName("회의실1");
         assertEquals(room, MeetingRoom.ROOM1);
     }
 }

--- a/src/test/java/com/h3/reservation/slackcalendar/converter/ReservationConverterTest.java
+++ b/src/test/java/com/h3/reservation/slackcalendar/converter/ReservationConverterTest.java
@@ -1,0 +1,47 @@
+package com.h3.reservation.slackcalendar.converter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author heebg
+ * @version 1.0
+ * @date 2019-12-13
+ */
+class ReservationConverterTest {
+    private final String summaryDelimiter = "/";
+    private static String[] unFormatted = {
+        "회의실/제목/목적"
+        , "회의실//목적"
+        , "회의실/제목/"
+        , "회의실2//"
+        , "//"
+        , "회의실2,//제목/"
+        , "회의실2,제목,목적제목/"
+        , "으아앙"
+    };
+
+    @Test
+    void isFormatted() {
+        String summary = "회의실2/제목/목적";
+
+        assertTrue(ReservationConverter.isFormatted(summary, summaryDelimiter));
+    }
+
+    @ParameterizedTest
+    @MethodSource("unFormattedSummaries")
+    void isFormattedError(final String summary) {
+        assertFalse(ReservationConverter.isFormatted(summary, summaryDelimiter));
+    }
+
+    private static Stream<String> unFormattedSummaries() {
+        return Stream.of(unFormatted);
+    }
+}


### PR DESCRIPTION
[#61] slack : 형식에 맞지 않는 예약이 있을 경우 조회시 무시하게 변경


현재 형식에 맞는지 판단하는 로직을 `ReservationConverter`에 추가했는데 더 좋은 위치가 있을지 고민입니당.
`회의실/이름/제목` 은 언제든 바뀔 수 있는 로직이라 `Reservation`보단 `Converter`가 가지고 있는게 더 좋을 것 같아 넣었습니당. 